### PR TITLE
feat: add activity type selection to ManageTreks and ExplorePage comp…

### DIFF
--- a/app/src/components/admin/dashboard/ManageTreks.jsx
+++ b/app/src/components/admin/dashboard/ManageTreks.jsx
@@ -2,17 +2,18 @@ import { useState, useEffect, useRef } from 'react';
 import { PencilIcon, TrashIcon, PlusIcon, XMarkIcon } from '@heroicons/react/24/outline';
 import { ChevronLeftIcon, ChevronRightIcon } from '@heroicons/react/20/solid';
 import treksService from '../../../services/api/treksService';
+import { ACTIVITY_TYPE_LABELS } from '../../../constants/activityTypes';
 
 const ManageTreks = () => {
     // State for editing trek
     // State for adding trek
     const [isAddModalOpen, setIsAddModalOpen] = useState(false);
-    const [addForm, setAddForm] = useState({ name: '', location: '', difficulty: [], duration: '', status: 'Active' });
+    const [addForm, setAddForm] = useState({ name: '', location: '', difficulty: [], duration: '', status: 'Active', activityType: 'trek' });
     const [isAddLoading, setIsAddLoading] = useState(false);
 
     // Open add modal
     const handleAddClick = () => {
-        setAddForm({ name: '', location: '', difficulty: '', duration: '', status: 'Active' });
+        setAddForm({ name: '', location: '', difficulty: '', duration: '', status: 'Active', activityType: 'trek' });
         setIsAddModalOpen(true);
     };
 
@@ -57,6 +58,7 @@ const ManageTreks = () => {
                 difficulty: addForm.difficulty,
                 duration: addForm.duration,
                 status: addForm.status,
+                activityType: addForm.activityType,
             });
             setIsAddModalOpen(false);
             fetchTreks(pagination.currentPage, searchTerm);
@@ -103,7 +105,7 @@ const ManageTreks = () => {
     };
     const [isEditModalOpen, setIsEditModalOpen] = useState(false);
     const [editTrek, setEditTrek] = useState(null);
-    const [editForm, setEditForm] = useState({ name: '', location: '', difficulty: '', duration: '', status: '' });
+    const [editForm, setEditForm] = useState({ name: '', location: '', difficulty: '', duration: '', status: '', activityType: 'trek' });
     const [isEditLoading, setIsEditLoading] = useState(false);
     // State for custom multi-select dropdown (edit modal)
     // --- Custom Multi-Select Dropdown State for Edit Modal ---
@@ -137,6 +139,7 @@ const ManageTreks = () => {
             difficulty: Array.isArray(trek.difficulty) ? trek.difficulty : trek.difficulty ? [trek.difficulty] : [],
             duration: trek.duration || '',
             status: trek.status || '',
+            activityType: trek.activityType || 'trek',
         });
         setIsEditModalOpen(true);
         setShowDifficultyDropdown(false);
@@ -163,6 +166,7 @@ const ManageTreks = () => {
                 difficulty: editForm.difficulty,
                 duration: editForm.duration,
                 status: editForm.status,
+                activityType: editForm.activityType,
             });
             setIsEditModalOpen(false);
             setEditTrek(null);
@@ -434,6 +438,14 @@ const ManageTreks = () => {
                                         <option value="Inactive">Inactive</option>
                                     </select>
                                 </div>
+                                <div>
+                                    <label className="block text-sm font-medium mb-1">Activity Type</label>
+                                    <select name="activityType" value={addForm.activityType} onChange={handleAddFormChange} className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" required>
+                                        {Object.entries(ACTIVITY_TYPE_LABELS).map(([value, label]) => (
+                                            <option key={value} value={value}>{label}</option>
+                                        ))}
+                                    </select>
+                                </div>
                                 <div className="flex justify-end gap-2 pt-2">
                                     <button type="button" className="px-4 py-2 rounded-lg text-sm font-medium text-gray-700 border border-gray-300 hover:bg-gray-50 transition-colors" onClick={handleAddModalClose}>Cancel</button>
                                     <button type="submit" className="px-4 py-2 rounded-lg text-sm font-medium bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50 transition-colors" disabled={isAddLoading}>{isAddLoading ? 'Adding...' : 'Add Trek'}</button>
@@ -683,6 +695,14 @@ const ManageTreks = () => {
                                                                 <select name="status" value={editForm.status} onChange={handleEditFormChange} className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" required>
                                                                     <option value="Active">Active</option>
                                                                     <option value="Inactive">Inactive</option>
+                                                                </select>
+                                                            </div>
+                                                            <div>
+                                                                <label className="block text-sm font-medium mb-1">Activity Type</label>
+                                                                <select name="activityType" value={editForm.activityType} onChange={handleEditFormChange} className="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500" required>
+                                                                    {Object.entries(ACTIVITY_TYPE_LABELS).map(([value, label]) => (
+                                                                        <option key={value} value={value}>{label}</option>
+                                                                    ))}
                                                                 </select>
                                                             </div>
                                                             <div className="flex justify-end gap-2 pt-2">

--- a/app/src/components/explore/ExplorePage.jsx
+++ b/app/src/components/explore/ExplorePage.jsx
@@ -8,6 +8,7 @@ import { treksService } from '../../services/api/treksService';
 import Dropdown from './Dropdown';
 import { transformApiTrek } from '../../utils/utils'; // Adjust the import path as necessary
 import { Helmet } from 'react-helmet-async';
+import { ACTIVITY_TYPE_LABELS } from '../../constants/activityTypes';
 
 const ExplorePage = () => {
     const [treks, setTreks] = useState([]);
@@ -19,7 +20,8 @@ const ExplorePage = () => {
         duration: [],
         location: [],
         price: [],
-        community: []
+        community: [],
+        activityType: [],
     });
     const [isServerSearch, setIsServerSearch] = useState(true);
 
@@ -210,6 +212,10 @@ const ExplorePage = () => {
 
             if (activeFilters.community.length > 0) {
                 filterParams.community = activeFilters.community;
+            }
+
+            if (activeFilters.activityType.length > 0) {
+                filterParams.activityType = activeFilters.activityType;
             }
 
             // Check if any filters are applied
@@ -406,9 +412,26 @@ const ExplorePage = () => {
                         placeholder="All"
                         buttonClass="border-purple-300 focus:ring-purple-500 hover:border-purple-400"
                     />
+                    {/* Activity Type Dropdown */}
+                    <Dropdown
+                        label="Activity Type:"
+                        id="activity-type-select"
+                        options={
+                            filterMetadata && Array.isArray(filterMetadata)
+                                ? (filterMetadata.find(f => f.name === 'activityType')?.options || [])
+                                : []
+                        }
+                        value={activeFilters.activityType}
+                        onChange={vals => setActiveFilters(prev => ({
+                            ...prev,
+                            activityType: vals
+                        }))}
+                        placeholder="All"
+                        buttonClass="border-orange-300 focus:ring-orange-500 hover:border-orange-400"
+                    />
                 </div>
                 {/* Active Filters Display as removable pills */}
-                {(activeFilters.difficulty.length > 0 || activeFilters.duration.length > 0 || activeFilters.location.length > 0) && (
+                {(activeFilters.difficulty.length > 0 || activeFilters.duration.length > 0 || activeFilters.location.length > 0 || activeFilters.activityType.length > 0) && (
                     <div className="mb-4 flex flex-wrap gap-2 items-center">
                         <span className="text-gray-700 font-medium">Active Filters:</span>
                         {activeFilters.difficulty.map(val => (
@@ -452,6 +475,22 @@ const ExplorePage = () => {
                                     onClick={() => setActiveFilters(prev => ({
                                         ...prev,
                                         location: prev.location.filter(v => v !== val)
+                                    }))}
+                                    aria-label={`Remove ${val} filter`}
+                                >
+                                    &times;
+                                </button>
+                            </span>
+                        ))}
+                        {activeFilters.activityType.map(val => (
+                            <span key={val} className="flex items-center px-2 py-1 bg-orange-100 text-orange-800 rounded-full text-xs font-semibold">
+                                {ACTIVITY_TYPE_LABELS[val] || val}
+                                <button
+                                    type="button"
+                                    className="ml-1 text-orange-500 hover:text-orange-700 focus:outline-none"
+                                    onClick={() => setActiveFilters(prev => ({
+                                        ...prev,
+                                        activityType: prev.activityType.filter(v => v !== val)
                                     }))}
                                     aria-label={`Remove ${val} filter`}
                                 >

--- a/app/src/components/ui/TrekCard.jsx
+++ b/app/src/components/ui/TrekCard.jsx
@@ -3,6 +3,7 @@ import { motion } from 'framer-motion';
 import { Link } from 'react-router-dom';
 import { useState } from 'react';
 import { ClockIcon, MapPinIcon, StarIcon, ArrowTrendingUpIcon, CheckCircleIcon } from '@heroicons/react/24/solid';
+import { ACTIVITY_TYPE_LABELS } from '../../constants/activityTypes';
 
 const TrekCard = ({ trek, isSelectable = false, isSelected = false, onToggleSelect }) => {
   const [showTooltip, setShowTooltip] = useState(false);
@@ -15,6 +16,7 @@ const TrekCard = ({ trek, isSelectable = false, isSelected = false, onToggleSele
     duration, 
     rating, 
     elevation,
+    activityType,
   } = trek;
 
   const difficultyColor = {
@@ -70,6 +72,11 @@ const TrekCard = ({ trek, isSelectable = false, isSelected = false, onToggleSele
              <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${difficultyColor[difficulty.toLowerCase()]}`}>
             {difficulty}
           </span>
+          {activityType && activityType !== 'trek' && (
+            <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-orange-100 text-orange-800">
+              {ACTIVITY_TYPE_LABELS[activityType] || activityType}
+            </span>
+          )}
           {isSelectable && (
             <div 
               onClick={(e) => {

--- a/app/src/constants/activityTypes.js
+++ b/app/src/constants/activityTypes.js
@@ -1,0 +1,7 @@
+export const ACTIVITY_TYPE_LABELS = {
+    trek:        'Trek',
+    day_hike:    'Day Hike',
+    trail_walk:  'Trail Walk',
+    nature_walk: 'Nature Walk',
+    expedition:  'Expedition',
+};

--- a/app/src/utils/utils.js
+++ b/app/src/utils/utils.js
@@ -11,7 +11,8 @@ export const transformApiTrek = (apiTrek) => {
         price: apiTrek.cost ? parseInt(apiTrek.cost.replace(',', '')) : 999,
         description: `Trek to ${apiTrek.title} - Elevation: ${apiTrek.elevation || 'N/A'}`,
         elevation: apiTrek.elevation,
-        community: apiTrek.org || "Unknown"
+        community: apiTrek.org || "Unknown",
+        activityType: apiTrek.activityType || 'trek',
     };
 };
 


### PR DESCRIPTION
This pull request adds support for an "Activity Type" field to treks across the admin dashboard, explore page, and trek cards. Admins can now set an activity type when creating or editing a trek, users can filter treks by activity type on the explore page, and the activity type is displayed on trek cards. The change also introduces a central mapping for activity type labels.

**Admin Dashboard Enhancements:**
- Added an `activityType` field to the add and edit trek forms, defaulting to `'trek'`, and ensured it is sent to the backend when creating or updating treks. [[1]](diffhunk://#diff-1c329dabd7995a396226ae8cc49dd4077f93e28e73bce04356918e9c004a54bfR5-R16) [[2]](diffhunk://#diff-1c329dabd7995a396226ae8cc49dd4077f93e28e73bce04356918e9c004a54bfR61) [[3]](diffhunk://#diff-1c329dabd7995a396226ae8cc49dd4077f93e28e73bce04356918e9c004a54bfL106-R108) [[4]](diffhunk://#diff-1c329dabd7995a396226ae8cc49dd4077f93e28e73bce04356918e9c004a54bfR142) [[5]](diffhunk://#diff-1c329dabd7995a396226ae8cc49dd4077f93e28e73bce04356918e9c004a54bfR169) [[6]](diffhunk://#diff-1c329dabd7995a396226ae8cc49dd4077f93e28e73bce04356918e9c004a54bfR441-R448) [[7]](diffhunk://#diff-1c329dabd7995a396226ae8cc49dd4077f93e28e73bce04356918e9c004a54bfR700-R707)

**Explore Page Filtering:**
- Added an activity type filter to the explore page, allowing users to filter treks by activity type and see active filters as removable pills. [[1]](diffhunk://#diff-fe9a3a70e691d0ee5bb27bc8f4883aa435f3929e3bd2e5780c3b2b5a8244bcd3R11) [[2]](diffhunk://#diff-fe9a3a70e691d0ee5bb27bc8f4883aa435f3929e3bd2e5780c3b2b5a8244bcd3L22-R24) [[3]](diffhunk://#diff-fe9a3a70e691d0ee5bb27bc8f4883aa435f3929e3bd2e5780c3b2b5a8244bcd3R217-R220) [[4]](diffhunk://#diff-fe9a3a70e691d0ee5bb27bc8f4883aa435f3929e3bd2e5780c3b2b5a8244bcd3R415-R434) [[5]](diffhunk://#diff-fe9a3a70e691d0ee5bb27bc8f4883aa435f3929e3bd2e5780c3b2b5a8244bcd3R485-R500)

**Trek Card Display:**
- Trek cards now display the activity type (if not the default `'trek'`) using the appropriate label. [[1]](diffhunk://#diff-52eb2c0d3e485d55f7bda1052956e82daa2a62cbb354f127fa28ae626bbf8b04R6) [[2]](diffhunk://#diff-52eb2c0d3e485d55f7bda1052956e82daa2a62cbb354f127fa28ae626bbf8b04R19) [[3]](diffhunk://#diff-52eb2c0d3e485d55f7bda1052956e82daa2a62cbb354f127fa28ae626bbf8b04R75-R79)

**Centralized Activity Type Labels:**
- Introduced `ACTIVITY_TYPE_LABELS` in `constants/activityTypes.js` for consistent labeling throughout the app.

**Data Transformation:**
- The `transformApiTrek` utility now includes `activityType`, defaulting to `'trek'` if not present.…onents